### PR TITLE
Make signing key not required

### DIFF
--- a/lib/actor.ex
+++ b/lib/actor.ex
@@ -16,7 +16,7 @@ defmodule CommonsPub.Actors.Actor do
 
   @defaults [
     cast: [:signing_key],
-    required: [:signing_key]
+    required: []
   ]
 
   def changeset(actor \\ %Actor{}, attrs, opts \\ []) do


### PR DESCRIPTION
Signing key is generated later and is expected to be nil when the user is first created/